### PR TITLE
Remove :export-block

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -100,7 +100,6 @@ default fragment style, otherwise return \"fragment style\"."
     (template . org-reveal-template))
 
   :filters-alist '((:filter-parse-tree . org-reveal-filter-parse-tree))
-  :export-block '("REVEAL" "NOTES")
   )
 
 (defcustom org-reveal-root "./reveal.js"


### PR DESCRIPTION
The `:export-block` property has been deprecated in newer versions of `org-mode`, and causes an error when the file is loaded. This PR simply removes it, which fixes this backend for never releases of `org-mode` and Emacs.